### PR TITLE
取引一覧のapi定義一部事項の追加

### DIFF
--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -147,46 +147,92 @@ paths:
           description: Not Found
         '500':
           description: Internal Server Error
-  /tradingItems:
+  /borrowingItems:
     get:
       tags:
         - Trading
-      description: 商品取引情報取得
-      operationId: GettradingItems
+      description: 商品借用情報取得
+      operationId: GetborrowingItems
       parameters:
         - $ref: '#/components/parameters/UserId'
       responses:
         '200':
-          description: 商品取引情報取得成功
+          description: 商品借用情報取得成功
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/tradingItems'
+                  $ref: '#/components/schemas/borrowingItems'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /tradingKnowledges:
+  /rentingItems:
     get:
       tags:
         - Trading
-      description: ナレッジ取引情報取得
-      operationId: GettradingKnowledges
+      description: 商品貸出情報取得
+      operationId: GetrentingItems
       parameters:
         - $ref: '#/components/parameters/UserId'
       responses:
         '200':
-          description: ナレッジ取引情報取得成功
+          description: 商品貸出情報取得成功
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/tradingKnowledges'
+                  $ref: '#/components/schemas/rentingItems'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /borrowingKnowledges:
+    get:
+      tags:
+        - Trading
+      description: ナレッジ借用情報取得
+      operationId: GetborrowingKnowledges
+      parameters:
+        - $ref: '#/components/parameters/UserId'
+      responses:
+        '200':
+          description: ナレッジ借用情報取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/borrowingKnowledges'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /rentingKnowledges:
+    get:
+      tags:
+        - Trading
+      description: ナレッジ貸出情報取得
+      operationId: GetrentingKnowledges
+      parameters:
+        - $ref: '#/components/parameters/UserId'
+      responses:
+        '200':
+          description: ナレッジ貸出情報取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/rentingKnowledges'
         default:
           description: unexpected error
           content:
@@ -522,7 +568,7 @@ components:
               hold_status:
                 type: string
                 example: '開催済み'
-    tradingItems:
+    borrowingItems:
       type: array
       items:
         type: object
@@ -533,6 +579,10 @@ components:
           name:
             type: string
             example: 'Breakfast'
+          borrow_status:
+            description: 1=借用中,2=返却済み
+            type: number
+            example: 1
           points:
             type: number
             example: 1000
@@ -548,7 +598,7 @@ components:
           created_at:
             type: string
             example: '2022/02/11'
-    tradingKnowledges:
+    rentingItems:
       type: array
       items:
         type: object
@@ -559,10 +609,74 @@ components:
           name:
             type: string
             example: 'Breakfast'
+          rent_status:
+            description: 1=貸出中,2=貸出申請中
+            type: number
+            example: 1
+          points:
+            type: number
+            example: 1000
+          borrower:
+            type: string
+            example: 'kashiken'
+          img:
+            type: string
+            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
+          is_display:
+            type: boolean
+            example: false
+          created_at:
+            type: string
+            example: '2022/02/11'
+    borrowingKnowledges:
+      type: array
+      items:
+        type: object
+        properties:
+          id: 
+            type: number
+            example: 1
+          name:
+            type: string
+            example: 'Breakfast'
+          borrow_status:
+            description: 1=借用中,2=返却済み
+            type: number
+            example: 1
           points:
             type: number
             example: 1000
           booker:
+            type: string
+            example: 'kashiken'
+          img:
+            type: string
+            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
+          is_display:
+            type: boolean
+            example: false
+          created_at:
+            type: string
+            example: '2022/02/11'
+    rentingKnowledges:
+      type: array
+      items:
+        type: object
+        properties:
+          id: 
+            type: number
+            example: 1
+          name:
+            type: string
+            example: 'Breakfast'
+          rent_status:
+            description: 1=貸出中,2=貸出申請中
+            type: number
+            example: 1
+          points:
+            type: number
+            example: 1000
+          participant:
             type: string
             example: 'kashiken'
           img:


### PR DESCRIPTION
## 関連イシュー

- #19 

## なぜこの変更が必要なのか？どのような問題を解決するのか？

- 商品取引情報とナレッジ取引情報の借用中か返却済みのステータス、貸出中か貸出申請中のステータスの記入を行っていなかった。

## 検証したこと

- OpenApi SwaggerUI Previewで正確に表示されていることを確認した。

## エビデンス

<img width="685" alt="スクリーンショット 2023-05-06 11 35 33" src="https://user-images.githubusercontent.com/94788880/236594225-fd91d5b8-8f38-4350-abfd-18215d8d2f52.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 35 41" src="https://user-images.githubusercontent.com/94788880/236594231-d7ea675e-87d3-44ca-b26a-db9ac0b6ef99.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 35 52" src="https://user-images.githubusercontent.com/94788880/236594233-d10f237d-b003-45bb-b102-9af3bd70b193.png">


<img width="685" alt="スクリーンショット 2023-05-06 11 36 01" src="https://user-images.githubusercontent.com/94788880/236594249-bebc7b1f-c4a0-4145-932c-437757909208.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 36 09" src="https://user-images.githubusercontent.com/94788880/236594257-14d0c5a5-a1bf-41ee-9eb4-eff6b7a1e450.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 36 16" src="https://user-images.githubusercontent.com/94788880/236594272-7f32ffba-5679-4341-8c2b-353c381e6054.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 36 25" src="https://user-images.githubusercontent.com/94788880/236594285-73e9373e-0ad5-406c-a43b-d0328bd7d34f.png">

<img width="685" alt="スクリーンショット 2023-05-06 11 36 30" src="https://user-images.githubusercontent.com/94788880/236594292-eb9df4bd-6b2a-44a9-99fb-fa5c3b77e28e.png">



## 確認項目

- [ ] Development で Issue と紐付け済
- [ ] "Review Wanted"タグ付与済み
- [ ] console のエラー確認済
- [ ] Linter のエラー確認済
- [ ] ファイルの最後に改行を追加済み
- [ ] 無駄な改行・スペースがないか
- [ ] コードフォーマッタかけたか
- [ ] コメントは適切か（不要なコメントアウトの削除、PHPDocなどの記述）
- [ ] 使用済みのブランチ削除済(marge 後)
