### PR TITLE
管理者の全商品一覧のapi定義完了

### DIFF
--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -891,6 +891,8 @@ components:
             example: 1000
           status:
             description: 1,貸出中,2,出品中,3,公開停止中
+            type: number
+            example: 1
           ownerInfo:
             type: object
             properties:

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -110,7 +110,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Knowledge'
+                $ref: '#/components/schemas/Item'
         '404':
           description: Not Found
         '500':
@@ -142,7 +142,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Item'
+                $ref: '#/components/schemas/Knowledge'
         '404':
           description: Not Found
         '500':
@@ -339,7 +339,7 @@ paths:
           description: Not Found
         '500':
           description: Internal Server Error
-  /allItems:
+  /itemsManagement:
     get:
       tags:
         - Admin
@@ -351,22 +351,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/allItems'
-        '500':
-          description: Internal Server Error
-  /allItem/{id}:
-    get:
-      tags:
-        - Admin
-      description: 商品の情報を一つ取得する
-      operationId: GetallItem
-      responses:
-        '200':
-          description: 商品の情報を一つ取得成功
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/allItem'
+                $ref: '#/components/schemas/itemsManagement'
         '500':
           description: Internal Server Error
 components:
@@ -889,115 +874,60 @@ components:
           format: int32
         message:
           type: string
-    allItems:
-      description: 全ての商品情報
-      type: object
-      properties: 
-        id:
-          type: number
-          example: 1
-        price: 
-          type: number
-          example: 1000
-        title: 
-          type: string
-          example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
-        ownerInfo:
-          type: object
-          properties:
-            id:
-              type: number
-              example: 1
-            name:
-              type: string
-              example: 'かしけん'
-            img:
-              type: string
-              example: 'logo'
-        is_item:
-          description: 1=商品,2=ナレッジ
-          type: number
-          example: 1
-        img:
-          type: array
-          items: 
+    itemsManagement:
+      type: array
+      items:
+        description: 全ての商品情報
+        type: object
+        properties: 
+          price: 
+            type: number
+            example: 1000
+          title: 
             type: string
-            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
-        transactions:
-          type: array
-          items:
+            example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
+          ownerInfo:
             type: object
             properties:
-              id: 
+              id:
                 type: number
                 example: 1
-              start_date:
-                type: number
-                example: '2022/02/11'
-              points:
-                type: number
-                example: 1000
-              borrower:
+              name:
                 type: string
-                example: 'kashiken'
-              return_date:
+                example: 'かしけん'
+              img:
                 type: string
-                example: '2022/4/14'
-    allItem:
-      description: 一つの商品情報
-      type: object
-      properties: 
-        id:
-          type: number
-          example: 1
-        price: 
-          type: number
-          example: 1000
-        title: 
-          type: string
-          example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
-        ownerInfo:
-          type: object
-          properties:
-            id:
-              type: number
-              example: 1
-            name:
+                example: 'logo'
+          is_item:
+            description: 1=商品,2=ナレッジ
+            type: number
+            example: 1
+          img:
+            type: array
+            items: 
               type: string
-              example: 'かしけん'
-            img:
-              type: string
-              example: 'logo'
-        is_item:
-          description: 1=商品,2=ナレッジ
-          type: number
-          example: 1
-        img:
-          type: array
-          items: 
-            type: string
-            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
-        transactions:
-          type: array
-          items:
-            type: object
-            properties:
-              id: 
-                type: number
-                example: 1
-              start_date:
-                type: number
-                example: '2022/02/11'
-              points:
-                type: number
-                example: 1000
-              borrower:
-                type: string
-                example: 'kashiken'
-              return_date:
-                type: string
-                example: '2022/4/14'
-tags:
+              example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
+          transactions:
+            type: array
+            items:
+              type: object
+              properties:
+                id: 
+                  type: number
+                  example: 1
+                start_date:
+                  type: number
+                  example: '2022/02/11'
+                points:
+                  type: number
+                  example: 1000
+                borrower:
+                  type: string
+                  example: 'kashiken'
+                return_date:
+                  type: string
+                  example: '2022/4/14'
+tags:  
   - name: Users
     description: ユーザーに関するAPI
   - name: UserInfo

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -339,6 +339,36 @@ paths:
           description: Not Found
         '500':
           description: Internal Server Error
+  /allItems:
+    get:
+      tags:
+        - Admin
+      description: 商品の情報を全て取得する
+      operationId: GetallItems
+      responses:
+        '200':
+          description: 商品の情報全て取得成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/allItems'
+        '500':
+          description: Internal Server Error
+  /allItem/{id}:
+    get:
+      tags:
+        - Admin
+      description: 商品の情報を一つ取得する
+      operationId: GetallItem
+      responses:
+        '200':
+          description: 商品の情報を一つ取得成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/allItem'
+        '500':
+          description: Internal Server Error
 components:
   securitySchemes:
     Bearer:
@@ -859,6 +889,114 @@ components:
           format: int32
         message:
           type: string
+    allItems:
+      description: 全ての商品情報
+      type: object
+      properties: 
+        id:
+          type: number
+          example: 1
+        price: 
+          type: number
+          example: 1000
+        title: 
+          type: string
+          example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
+        ownerInfo:
+          type: object
+          properties:
+            id:
+              type: number
+              example: 1
+            name:
+              type: string
+              example: 'かしけん'
+            img:
+              type: string
+              example: 'logo'
+        is_item:
+          description: 1=商品,2=ナレッジ
+          type: number
+          example: 1
+        img:
+          type: array
+          items: 
+            type: string
+            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
+        transactions:
+          type: array
+          items:
+            type: object
+            properties:
+              id: 
+                type: number
+                example: 1
+              start_date:
+                type: number
+                example: '2022/02/11'
+              points:
+                type: number
+                example: 1000
+              borrower:
+                type: string
+                example: 'kashiken'
+              return_date:
+                type: string
+                example: '2022/4/14'
+    allItem:
+      description: 一つの商品情報
+      type: object
+      properties: 
+        id:
+          type: number
+          example: 1
+        price: 
+          type: number
+          example: 1000
+        title: 
+          type: string
+          example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
+        ownerInfo:
+          type: object
+          properties:
+            id:
+              type: number
+              example: 1
+            name:
+              type: string
+              example: 'かしけん'
+            img:
+              type: string
+              example: 'logo'
+        is_item:
+          description: 1=商品,2=ナレッジ
+          type: number
+          example: 1
+        img:
+          type: array
+          items: 
+            type: string
+            example: 'https://images.unsplash.com/photo-1551963831-b3b1ca40c98e'
+        transactions:
+          type: array
+          items:
+            type: object
+            properties:
+              id: 
+                type: number
+                example: 1
+              start_date:
+                type: number
+                example: '2022/02/11'
+              points:
+                type: number
+                example: 1000
+              borrower:
+                type: string
+                example: 'kashiken'
+              return_date:
+                type: string
+                example: '2022/4/14'
 tags:
   - name: Users
     description: ユーザーに関するAPI

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -880,12 +880,17 @@ components:
         description: 全ての商品情報
         type: object
         properties: 
-          price: 
+          id:
             type: number
-            example: 1000
+            example: 1
           title: 
             type: string
             example: 'MacbookPro 2018 core i7 2.6GHz 16GB 512GB'
+          price: 
+            type: number
+            example: 1000
+          status:
+            description: 1,貸出中,2,出品中,3,公開停止中
           ownerInfo:
             type: object
             properties:
@@ -898,7 +903,7 @@ components:
               img:
                 type: string
                 example: 'logo'
-          is_item:
+          kind:
             description: 1=商品,2=ナレッジ
             type: number
             example: 1


### PR DESCRIPTION
## 関連イシュー

- #31 

## なぜこの変更が必要なのか？どのような問題を解決するのか？

- 管理者の前商品一覧画面実装時のおおまかな方針の決定
- 商品とナレッジの記載内容が逆になっていたので修正。
- 管理者の商品詳細画面がユーザーの使用する商品詳細画面と一緒だったので管理者の商品詳細を削除
- 管理者の前商品一覧画面で出品状況のステータス、商品の種類のカラムの文言に誤解を招くような記述をしていたため訂正した。

## 検証したこと

OpenAPISwaggerUI Previewで正確に表示されていることを確認した。

## エビデンス
<img width="603" alt="スクリーンショット 2023-05-06 15 06 27" src="https://user-images.githubusercontent.com/94788880/236603921-6facb39a-52e8-49e6-8596-b94de1a9d841.png">

<img width="603" alt="スクリーンショット 2023-05-06 15 07 11" src="https://user-images.githubusercontent.com/94788880/236604057-0c5e9794-66f5-45da-a6f4-52f16a6e2cf5.png">

<img width="603" alt="スクリーンショット 2023-05-06 15 07 19" src="https://user-images.githubusercontent.com/94788880/236604170-ead53ca4-bf2c-4b56-b8d6-82c5c83581b6.png">

<img width="603" alt="スクリーンショット 2023-05-06 15 07 29" src="https://user-images.githubusercontent.com/94788880/236604206-cb563679-08e1-410b-a74f-d6764a9fb4ae.png">

<img width="603" alt="スクリーンショット 2023-05-06 15 07 35" src="https://user-images.githubusercontent.com/94788880/236604249-a83988f2-6eda-4044-b7d2-6ca2935c0432.png">

<img width="603" alt="スクリーンショット 2023-05-06 15 24 56" src="https://user-images.githubusercontent.com/94788880/236606198-0c03a8d7-f3ce-453f-96fb-9e59861626c2.png">




## 確認項目

- [ ] Development で Issue と紐付け済
- [ ] "Review Wanted"タグ付与済み
- [ ] console のエラー確認済
- [ ] Linter のエラー確認済
- [ ] ファイルの最後に改行を追加済み
- [ ] 無駄な改行・スペースがないか
- [ ] コードフォーマッタかけたか
- [ ] コメントは適切か（不要なコメントアウトの削除、PHPDocなどの記述）
- [ ] 使用済みのブランチ削除済(marge 後)
